### PR TITLE
StringLike no longer assumes toString is a no op. StringLike Benchmarks

### DIFF
--- a/test/benchmarks/src/main/scala/scala/collection/StringOpsBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/StringOpsBenchmark.scala
@@ -1,0 +1,79 @@
+package scala.collection
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import scala.util.Random
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 20)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+class StringOpsBenchmark {
+  @Param(Array("0", "1", "10", "100", "1000"))
+  var size: Int = _
+
+  var prefix: String = _
+  var suffix: String = _
+
+  // Used when we want to test stripPrefix etc with a string which is definately not present
+  var impossibleString: String = _
+
+  var testObject: StringOps = _
+
+  @Setup(Level.Trial) def initKeys(): Unit = {
+    val randomString = Random.nextString(size)
+
+    testObject = new StringOps(randomString)
+
+    val prefixAndSuffixLength = size / 10
+    prefix = randomString.substring(0, prefixAndSuffixLength)
+    suffix = randomString.reverse.substring(0, prefixAndSuffixLength)
+
+    impossibleString = randomString * 2
+  }
+
+  @Benchmark def linesWithSeparators: Any = {
+    testObject.linesWithSeparators
+  }
+
+  @Benchmark def lines: Any = {
+    testObject.lines
+  }
+
+  @Benchmark def capitalize: Any = {
+    testObject.capitalize
+  }
+
+  @Benchmark def stripPrefix_present: Any = {
+    testObject.stripPrefix(prefix)
+  }
+
+  @Benchmark def stripPrefix_notPresent: Any = {
+    testObject.stripPrefix(impossibleString)
+  }
+
+  @Benchmark def stripSuffix_present: Any = {
+    testObject.stripSuffix(prefix)
+  }
+
+  @Benchmark def stripSuffix_notPresent: Any = {
+    testObject.stripSuffix(impossibleString)
+  }
+
+  @Benchmark def replaceAllLiterally: Any = {
+    testObject.replaceAllLiterally("A", "B")
+  }
+
+  @Benchmark def stripMargin: Any = {
+    testObject.stripMargin
+  }
+
+  @Benchmark def split: Any = {
+    testObject.split('A')
+  }
+}


### PR DESCRIPTION
Addresses #29 
This was with 10 iterations. Going to run with 20 and 2.13 now and try and get better results.

Running on 2.12
```[info] # Run complete. Total time: 00:34:57
[info]
[info] Benchmark                                   (size)  Mode  Cnt     Score      Error  Units
[info] StringLikeBenchmark.capitalize                   0  avgt   20     4.023 ▒    0.054  ns/op
[info] StringLikeBenchmark.capitalize                   1  avgt   20    30.634 ▒    0.179  ns/op
[info] StringLikeBenchmark.capitalize                  10  avgt   20    32.674 ▒    1.147  ns/op
[info] StringLikeBenchmark.capitalize                 100  avgt   20    55.477 ▒    0.092  ns/op
[info] StringLikeBenchmark.capitalize                1000  avgt   20   480.720 ▒    2.278  ns/op
[info] StringLikeBenchmark.lines                        0  avgt   20     9.728 ▒    0.098  ns/op
[info] StringLikeBenchmark.lines                        1  avgt   20     9.736 ▒    0.040  ns/op
[info] StringLikeBenchmark.lines                       10  avgt   20     9.817 ▒    0.206  ns/op
[info] StringLikeBenchmark.lines                      100  avgt   20     9.744 ▒    0.046  ns/op
[info] StringLikeBenchmark.lines                     1000  avgt   20     9.715 ▒    0.080  ns/op
[info] StringLikeBenchmark.linesWithSeparators          0  avgt   20     7.021 ▒    0.024  ns/op
[info] StringLikeBenchmark.linesWithSeparators          1  avgt   20     7.079 ▒    0.140  ns/op
[info] StringLikeBenchmark.linesWithSeparators         10  avgt   20     7.021 ▒    0.020  ns/op
[info] StringLikeBenchmark.linesWithSeparators        100  avgt   20     7.068 ▒    0.024  ns/op
[info] StringLikeBenchmark.linesWithSeparators       1000  avgt   20     6.995 ▒    0.019  ns/op
[info] StringLikeBenchmark.replaceAllLiterally          0  avgt   20   130.837 ▒    0.380  ns/op
[info] StringLikeBenchmark.replaceAllLiterally          1  avgt   20   137.519 ▒    1.365  ns/op
[info] StringLikeBenchmark.replaceAllLiterally         10  avgt   20   141.065 ▒    0.445  ns/op
[info] StringLikeBenchmark.replaceAllLiterally        100  avgt   20   171.398 ▒    0.347  ns/op
[info] StringLikeBenchmark.replaceAllLiterally       1000  avgt   20   507.984 ▒    8.297  ns/op
[info] StringLikeBenchmark.split                        0  avgt   20    19.548 ▒    0.548  ns/op
[info] StringLikeBenchmark.split                        1  avgt   20    21.131 ▒    0.034  ns/op
[info] StringLikeBenchmark.split                       10  avgt   20    24.397 ▒    0.230  ns/op
[info] StringLikeBenchmark.split                      100  avgt   20    57.838 ▒    0.155  ns/op
[info] StringLikeBenchmark.split                     1000  avgt   20   392.646 ▒    0.522  ns/op
[info] StringLikeBenchmark.stripMargin                  0  avgt   20    52.154 ▒    0.123  ns/op
[info] StringLikeBenchmark.stripMargin                  1  avgt   20    73.597 ▒    0.376  ns/op
[info] StringLikeBenchmark.stripMargin                 10  avgt   20   143.249 ▒    0.703  ns/op
[info] StringLikeBenchmark.stripMargin                100  avgt   20   859.138 ▒    3.027  ns/op
[info] StringLikeBenchmark.stripMargin               1000  avgt   20  4529.893 ▒ 2981.498  ns/op
[info] StringLikeBenchmark.stripPrefix_notPresent       0  avgt   20     6.028 ▒    0.208  ns/op
[info] StringLikeBenchmark.stripPrefix_notPresent       1  avgt   20     4.660 ▒    0.123  ns/op
[info] StringLikeBenchmark.stripPrefix_notPresent      10  avgt   20     4.648 ▒    0.037  ns/op
[info] StringLikeBenchmark.stripPrefix_notPresent     100  avgt   20     4.609 ▒    0.039  ns/op
[info] StringLikeBenchmark.stripPrefix_notPresent    1000  avgt   20     4.579 ▒    0.036  ns/op
[info] StringLikeBenchmark.stripPrefix_present          0  avgt   20     6.047 ▒    0.035  ns/op
[info] StringLikeBenchmark.stripPrefix_present          1  avgt   20     6.345 ▒    0.240  ns/op
[info] StringLikeBenchmark.stripPrefix_present         10  avgt   20    20.282 ▒    0.125  ns/op
[info] StringLikeBenchmark.stripPrefix_present        100  avgt   20    34.209 ▒    0.739  ns/op
[info] StringLikeBenchmark.stripPrefix_present       1000  avgt   20   222.836 ▒    0.617  ns/op
[info] StringLikeBenchmark.stripSuffix_notPresent       0  avgt   20     6.148 ▒    0.072  ns/op
[info] StringLikeBenchmark.stripSuffix_notPresent       1  avgt   20     4.725 ▒    0.178  ns/op
[info] StringLikeBenchmark.stripSuffix_notPresent      10  avgt   20     4.621 ▒    0.034  ns/op
[info] StringLikeBenchmark.stripSuffix_notPresent     100  avgt   20     4.651 ▒    0.098  ns/op
[info] StringLikeBenchmark.stripSuffix_notPresent    1000  avgt   20     4.583 ▒    0.035  ns/op
[info] StringLikeBenchmark.stripSuffix_present          0  avgt   20     6.106 ▒    0.079  ns/op
[info] StringLikeBenchmark.stripSuffix_present          1  avgt   20     6.240 ▒    0.106  ns/op
[info] StringLikeBenchmark.stripSuffix_present         10  avgt   20     7.648 ▒    0.013  ns/op
[info] StringLikeBenchmark.stripSuffix_present        100  avgt   20     7.646 ▒    0.010  ns/op
[info] StringLikeBenchmark.stripSuffix_present       1000  avgt   20     7.646 ▒    0.033  ns/op
[success] Total time: 2101 s, completed 18-Feb-2018 20:07:21

After change:
[info] # Run complete. Total time: 00:35:01
[info]
[info] Benchmark                                   (size)  Mode  Cnt     Score     Error  Units
[info] StringLikeBenchmark.capitalize                   0  avgt   20     3.931 ▒   0.049  ns/op
[info] StringLikeBenchmark.capitalize                   1  avgt   20    30.688 ▒   0.207  ns/op
[info] StringLikeBenchmark.capitalize                  10  avgt   20    31.543 ▒   0.286  ns/op
[info] StringLikeBenchmark.capitalize                 100  avgt   20    55.680 ▒   0.133  ns/op
[info] StringLikeBenchmark.capitalize                1000  avgt   20   478.713 ▒   0.430  ns/op
[info] StringLikeBenchmark.lines                        0  avgt   20    10.433 ▒   0.974  ns/op
[info] StringLikeBenchmark.lines                        1  avgt   20     9.765 ▒   0.048  ns/op
[info] StringLikeBenchmark.lines                       10  avgt   20     9.775 ▒   0.110  ns/op
[info] StringLikeBenchmark.lines                      100  avgt   20    10.068 ▒   0.480  ns/op
[info] StringLikeBenchmark.lines                     1000  avgt   20     9.683 ▒   0.019  ns/op
[info] StringLikeBenchmark.linesWithSeparators          0  avgt   20     7.053 ▒   0.024  ns/op
[info] StringLikeBenchmark.linesWithSeparators          1  avgt   20     7.040 ▒   0.022  ns/op
[info] StringLikeBenchmark.linesWithSeparators         10  avgt   20     7.064 ▒   0.025  ns/op
[info] StringLikeBenchmark.linesWithSeparators        100  avgt   20     7.049 ▒   0.024  ns/op
[info] StringLikeBenchmark.linesWithSeparators       1000  avgt   20     7.035 ▒   0.021  ns/op
[info] StringLikeBenchmark.replaceAllLiterally          0  avgt   20   131.391 ▒   0.143  ns/op
[info] StringLikeBenchmark.replaceAllLiterally          1  avgt   20   137.545 ▒   3.111  ns/op
[info] StringLikeBenchmark.replaceAllLiterally         10  avgt   20   142.045 ▒   0.477  ns/op
[info] StringLikeBenchmark.replaceAllLiterally        100  avgt   20   173.344 ▒   0.857  ns/op
[info] StringLikeBenchmark.replaceAllLiterally       1000  avgt   20   505.472 ▒   2.317  ns/op
[info] StringLikeBenchmark.split                        0  avgt   20    19.130 ▒   0.039  ns/op
[info] StringLikeBenchmark.split                        1  avgt   20    21.133 ▒   0.021  ns/op
[info] StringLikeBenchmark.split                       10  avgt   20    24.349 ▒   0.081  ns/op
[info] StringLikeBenchmark.split                      100  avgt   20    57.789 ▒   0.056  ns/op
[info] StringLikeBenchmark.split                     1000  avgt   20   392.722 ▒   0.543  ns/op
[info] StringLikeBenchmark.stripMargin                  0  avgt   20    52.426 ▒   0.293  ns/op
[info] StringLikeBenchmark.stripMargin                  1  avgt   20    74.577 ▒   0.572  ns/op
[info] StringLikeBenchmark.stripMargin                 10  avgt   20   143.505 ▒   0.443  ns/op
[info] StringLikeBenchmark.stripMargin                100  avgt   20   501.473 ▒ 316.484  ns/op
[info] StringLikeBenchmark.stripMargin               1000  avgt   20  7885.917 ▒   7.846  ns/op
[info] StringLikeBenchmark.stripPrefix_notPresent       0  avgt   20     5.517 ▒   0.206  ns/op
[info] StringLikeBenchmark.stripPrefix_notPresent       1  avgt   20     4.566 ▒   0.018  ns/op
[info] StringLikeBenchmark.stripPrefix_notPresent      10  avgt   20     4.616 ▒   0.103  ns/op
[info] StringLikeBenchmark.stripPrefix_notPresent     100  avgt   20     4.559 ▒   0.048  ns/op
[info] StringLikeBenchmark.stripPrefix_notPresent    1000  avgt   20     4.544 ▒   0.055  ns/op
[info] StringLikeBenchmark.stripPrefix_present          0  avgt   20     5.709 ▒   0.244  ns/op
[info] StringLikeBenchmark.stripPrefix_present          1  avgt   20     5.693 ▒   0.105  ns/op
[info] StringLikeBenchmark.stripPrefix_present         10  avgt   20    19.914 ▒   0.275  ns/op
[info] StringLikeBenchmark.stripPrefix_present        100  avgt   20    35.305 ▒   1.172  ns/op
[info] StringLikeBenchmark.stripPrefix_present       1000  avgt   20   220.878 ▒   0.238  ns/op
[info] StringLikeBenchmark.stripSuffix_notPresent       0  avgt   20     5.752 ▒   0.047  ns/op
[info] StringLikeBenchmark.stripSuffix_notPresent       1  avgt   20     4.612 ▒   0.023  ns/op
[info] StringLikeBenchmark.stripSuffix_notPresent      10  avgt   20     4.586 ▒   0.031  ns/op
[info] StringLikeBenchmark.stripSuffix_notPresent     100  avgt   20     4.641 ▒   0.045  ns/op
[info] StringLikeBenchmark.stripSuffix_notPresent    1000  avgt   20     4.644 ▒   0.073  ns/op
[info] StringLikeBenchmark.stripSuffix_present          0  avgt   20     5.742 ▒   0.072  ns/op
[info] StringLikeBenchmark.stripSuffix_present          1  avgt   20     5.783 ▒   0.055  ns/op
[info] StringLikeBenchmark.stripSuffix_present         10  avgt   20     8.057 ▒   0.220  ns/op
[info] StringLikeBenchmark.stripSuffix_present        100  avgt   20     7.886 ▒   0.054  ns/op
[info] StringLikeBenchmark.stripSuffix_present       1000  avgt   20     7.846 ▒   0.029  ns/op
[success] Total time: 2121 s, completed 18-Feb-2018 20:52:28```