### PR TITLE
Parallel rechecks and Improve perfomance of paralellization

### DIFF
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -418,6 +418,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
       implicit val ec: ExecutionContextExecutor = createExecutionContext()
 
       try {
+        Parallel.isParallel = isParallel
         _synchronizeNames = isParallel
 
         /* Every unit is now run in separate `Future`. If given phase is not ran as parallel one
@@ -444,7 +445,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
         }
       } finally {
         _synchronizeNames = false
-
+        Parallel.isParallel = false
         ec match {
           case ecxs: ExecutionContextExecutorService =>
             ecxs.shutdown()

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -90,7 +90,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
    * which at the end of the unit processing is dumped to the main reporter.
    * We need to do it if we want to retain the same messages order as in case of single threaded execution.
    */
-  private[this] val currentReporter: WorkerOrMainThreadLocal[Reporter] = WorkerThreadLocal(reporter0, reporter0)
+  private[this] val currentReporter = WorkerOrMainThreadLocal(reporter0)
   def reporter: Reporter =  currentReporter.get
   def reporter_=(newReporter: Reporter): Unit =
     currentReporter.set(newReporter match {

--- a/src/compiler/scala/tools/nsc/ast/Positions.scala
+++ b/src/compiler/scala/tools/nsc/ast/Positions.scala
@@ -1,6 +1,7 @@
 package scala.tools.nsc
 package ast
 
+import scala.reflect.internal.util.Parallel
 import scala.reflect.internal.util.Parallel.WorkerThreadLocal
 
 trait Positions extends scala.reflect.internal.Positions {
@@ -26,8 +27,8 @@ trait Positions extends scala.reflect.internal.Positions {
     }
   }
 
-  override protected[this] final val _posAssigner: WorkerThreadLocal[PosAssigner] = WorkerThreadLocal {
+  override protected[this] final val _posAssigner = new Parallel.LazyThreadLocal[PosAssigner](
     if (settings.Yrangepos && settings.debug || settings.Yposdebug) new ValidatingPosAssigner
     else new DefaultPosAssigner
-  }
+  )
 }

--- a/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
@@ -216,7 +216,7 @@ abstract class SymbolLoaders {
     override def complete(root: Symbol): Unit = {
       try {
         val start = java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(System.nanoTime())
-        withLocalPhase { doComplete(root) }
+        withSavedPhase { doComplete(root) }
         informTime("loaded " + description, start)
         ok = true
         setSource(root)

--- a/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
@@ -216,9 +216,7 @@ abstract class SymbolLoaders {
     override def complete(root: Symbol): Unit = {
       try {
         val start = java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(System.nanoTime())
-        val currentphase = phase
-        doComplete(root)
-        phase = currentphase
+        withLocalPhase { doComplete(root) }
         informTime("loaded " + description, start)
         ok = true
         setSource(root)

--- a/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
+++ b/src/compiler/scala/tools/nsc/symtab/SymbolLoaders.scala
@@ -340,7 +340,7 @@ abstract class SymbolLoaders {
   }
 
   /** used from classfile parser to avoid cycles */
-  private[this] final val _parentsLevel = Parallel.WorkerThreadLocal(0)
+  private[this] final val _parentsLevel = Parallel.IntWorkerThreadLocal(0)
   def parentsLevel = _parentsLevel.get
   def parentsLevel_=(v: Int): Unit = _parentsLevel.set(v)
 

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1260,8 +1260,8 @@ trait Contexts { self: Analyzer =>
     type Error = AbsTypeError
     type Warning = (Position, String)
 
-    protected def _errorBuffer = _rawBuffer
-    protected def _errorBuffer_=(v: mutable.LinkedHashSet[AbsTypeError]) = _rawBuffer = v
+    @inline protected def _errorBuffer = _rawBuffer
+    @inline protected def _errorBuffer_=(v: mutable.LinkedHashSet[AbsTypeError]) = _rawBuffer = v
 
     def issue(err: AbsTypeError)(implicit context: Context): Unit = handleError(context.fixPosition(err.errPos), addDiagString(err.errMsg))
 
@@ -1420,8 +1420,8 @@ trait Contexts { self: Analyzer =>
 
     private[this] val localBuffer =  Parallel.WorkerThreadLocal[mutable.LinkedHashSet[AbsTypeError]](null)
 
-    override protected def _errorBuffer = localBuffer.get
-    override protected def _errorBuffer_=(v: mutable.LinkedHashSet[AbsTypeError]) = localBuffer.set(v)
+    @inline override protected def _errorBuffer = localBuffer.get
+    @inline override protected def _errorBuffer_=(v: mutable.LinkedHashSet[AbsTypeError]) = localBuffer.set(v)
   }
 
   /** Used during a run of [[scala.tools.nsc.typechecker.TreeCheckers]]? */

--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -1256,9 +1256,12 @@ trait Contexts { self: Analyzer =>
    *
    *  To handle nested contexts, reporters share buffers. TODO: only buffer in BufferingReporter, emit immediately in ImmediateReporter
    */
-  abstract class ContextReporter(private[this] var _errorBuffer: mutable.LinkedHashSet[AbsTypeError] = null, private[this] var _warningBuffer: mutable.LinkedHashSet[(Position, String)] = null) extends Reporter {
+  abstract class ContextReporter(private[this] var _rawBuffer: mutable.LinkedHashSet[AbsTypeError] = null, private[this] var _warningBuffer: mutable.LinkedHashSet[(Position, String)] = null) extends Reporter {
     type Error = AbsTypeError
     type Warning = (Position, String)
+
+    protected def _errorBuffer = _rawBuffer
+    protected def _errorBuffer_=(v: mutable.LinkedHashSet[AbsTypeError]) = _rawBuffer = v
 
     def issue(err: AbsTypeError)(implicit context: Context): Unit = handleError(context.fixPosition(err.errPos), addDiagString(err.errMsg))
 
@@ -1314,7 +1317,7 @@ trait Contexts { self: Analyzer =>
         case INFO    => reporter.echo(pos, msg)
       }
 
-    final override def hasErrors = super.hasErrors || (_errorBuffer != null && errorBuffer.nonEmpty)
+    final override def hasErrors = super.hasErrors || (_errorBuffer != null && _errorBuffer.nonEmpty)
 
     // TODO: everything below should be pushed down to BufferingReporter (related to buffering)
     // Implicit relies on this most heavily, but there you know reporter.isInstanceOf[BufferingReporter]
@@ -1414,6 +1417,11 @@ trait Contexts { self: Analyzer =>
   private[typechecker] class ThrowingReporter extends ContextReporter {
     override def isThrowing = true
     protected def handleError(pos: Position, msg: String): Unit = throw new TypeError(pos, msg)
+
+    private[this] val localBuffer =  Parallel.WorkerThreadLocal[mutable.LinkedHashSet[AbsTypeError]](null)
+
+    override protected def _errorBuffer = localBuffer.get
+    override protected def _errorBuffer_=(v: mutable.LinkedHashSet[AbsTypeError]) = localBuffer.set(v)
   }
 
   /** Used during a run of [[scala.tools.nsc.typechecker.TreeCheckers]]? */

--- a/src/reflect/scala/reflect/api/Trees.scala
+++ b/src/reflect/scala/reflect/api/Trees.scala
@@ -2548,7 +2548,10 @@ trait Trees { self: Universe =>
       * That possibly could be solved by ensuring that every unit operates on it's own copy of the tree,
       * but it would require much bigger refactorings and would be more memory consuming.
       */
-   protected[scala] var currentOwner: Symbol = rootMirror.RootClass
+    @inline protected[scala] def currentOwner: Symbol = _currentOwner
+    @inline protected[scala] def currentOwner_=(sym: Symbol): Unit = _currentOwner = sym
+    private[this] var _currentOwner: Symbol = rootMirror.RootClass
+
 
     /** The enclosing method of the currently transformed tree. */
     protected def currentMethod = {

--- a/src/reflect/scala/reflect/api/Trees.scala
+++ b/src/reflect/scala/reflect/api/Trees.scala
@@ -2548,9 +2548,7 @@ trait Trees { self: Universe =>
       * That possibly could be solved by ensuring that every unit operates on it's own copy of the tree,
       * but it would require much bigger refactorings and would be more memory consuming.
       */
-    @inline protected[scala] final def currentOwner: Symbol = _currentOwner.get
-    @inline protected[scala] final def currentOwner_=(sym: Symbol): Unit = _currentOwner.set(sym)
-    private[this] final val _currentOwner: WorkerThreadLocal[Symbol] = WorkerThreadLocal(rootMirror.RootClass)
+   protected[scala] var currentOwner: Symbol = rootMirror.RootClass
 
     /** The enclosing method of the currently transformed tree. */
     protected def currentMethod = {

--- a/src/reflect/scala/reflect/internal/BaseTypeSeqs.scala
+++ b/src/reflect/scala/reflect/internal/BaseTypeSeqs.scala
@@ -70,7 +70,7 @@ trait BaseTypeSeqs {
       if(pending contains i) {
         pending.clear()
         throw CyclicInheritance
-      } else {
+      } else synchronizeSymbolsAccess {
         def computeLazyType(rtp: RefinedType): Type = {
           if (!isIntersectionTypeForLazyBaseType(rtp))
             devWarning("unexpected RefinedType in base type seq, lazy BTS elements should be created via intersectionTypeForLazyBaseType: " + rtp)

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -12,7 +12,7 @@ import scala.annotation.{meta, migration}
 import scala.collection.mutable
 import Flags._
 import scala.reflect.api.{Universe => ApiUniverse}
-import scala.reflect.internal.util.Parallel.WorkerThreadLocal
+import scala.reflect.internal.util.Parallel
 
 trait Definitions extends api.StandardDefinitions {
   self: SymbolTable =>
@@ -828,8 +828,8 @@ trait Definitions extends api.StandardDefinitions {
       }
     }
 
-    private[this] var volatileRecursions: WorkerThreadLocal[Int] = WorkerThreadLocal(0)
-    private[this] val pendingVolatiles = WorkerThreadLocal(mutable.HashSet[Symbol]())
+    private[this] var volatileRecursions = Parallel.IntWorkerThreadLocal(0)
+    private[this] val pendingVolatiles = Parallel.WorkerThreadLocal(mutable.HashSet[Symbol]())
     object PendingVolatilesLock extends util.Parallel.Lock
 
     def functionNBaseType(tp: Type): Type = tp.baseClasses find isFunctionSymbol match {

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -774,7 +774,7 @@ trait Definitions extends api.StandardDefinitions {
       // because volatile checking is done before all cycles are detected.
       // the case to avoid is an abstract type directly or
       // indirectly upper-bounded by itself. See #2918
-      def isVolatileAbstractType: Boolean = {
+      def isVolatileAbstractType: Boolean = PendingVolatilesLock {
         def sym = tp.typeSymbol
         def volatileUpperBound = isVolatile(tp.bounds.hi)
         def safeIsVolatile = (
@@ -829,6 +829,8 @@ trait Definitions extends api.StandardDefinitions {
 
     private[this] var volatileRecursions: Int = 0
     private[this] val pendingVolatiles = mutable.HashSet[Symbol]()
+    object PendingVolatilesLock extends util.Parallel.Lock
+
     def functionNBaseType(tp: Type): Type = tp.baseClasses find isFunctionSymbol match {
       case Some(sym) => tp baseType unspecializedSymbol(sym)
       case _         => tp

--- a/src/reflect/scala/reflect/internal/Positions.scala
+++ b/src/reflect/scala/reflect/internal/Positions.scala
@@ -283,7 +283,7 @@ trait Positions extends api.Positions { self: SymbolTable =>
   }
 
   // Reported by umad
-  protected[this] val _posAssigner: WorkerThreadLocal[PosAssigner] = WorkerThreadLocal(new DefaultPosAssigner)
+  protected[this] val _posAssigner = new Parallel.LazyThreadLocal[PosAssigner](new DefaultPosAssigner)
   @inline protected[this] final def posAssigner: PosAssigner = _posAssigner.get
 
   protected class DefaultPosAssigner extends PosAssigner {

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -223,8 +223,8 @@ abstract class SymbolTable extends macros.Universe
   final val NoRunId = 0
   // TODO add local for this as well
   private val phStack: collection.mutable.ArrayStack[Phase] = new collection.mutable.ArrayStack()
-  private[this] var ph: Parallel.WorkerOrMainThreadLocal[Phase] = Parallel.WorkerThreadLocal(NoPhase, NoPhase)
-  private[this] var per: Parallel.WorkerOrMainThreadLocal[Int] = Parallel.WorkerThreadLocal(NoPeriod, NoPeriod)
+  private[this] var ph: Parallel.WorkerOrMainThreadLocal[Phase] = Parallel.WorkerOrMainThreadLocal(NoPhase)
+  private[this] var per: Parallel.WorkerOrMainThreadLocal[Int] = Parallel.WorkerOrMainThreadLocal(NoPeriod)
 
   final def atPhaseStack: List[Phase] = phStack.toList
   final def phase: Phase = ph.get
@@ -241,8 +241,8 @@ abstract class SymbolTable extends macros.Universe
       ph.set(p)
       per.set(nextPeriod)
     } else {
-      ph = Parallel.WorkerThreadLocal(p, p)
-      per = Parallel.WorkerThreadLocal(nextPeriod, nextPeriod)
+      ph = Parallel.WorkerOrMainThreadLocal(p)
+      per = Parallel.WorkerOrMainThreadLocal(nextPeriod)
     }
   }
 

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -224,7 +224,7 @@ abstract class SymbolTable extends macros.Universe
   // TODO add local for this as well
   private val phStack: collection.mutable.ArrayStack[Phase] = new collection.mutable.ArrayStack()
   private[this] var ph: Parallel.WorkerOrMainThreadLocal[Phase] = Parallel.WorkerOrMainThreadLocal(NoPhase)
-  private[this] var per: Parallel.WorkerOrMainThreadLocal[Int] = Parallel.WorkerOrMainThreadLocal(NoPeriod)
+  private[this] var per = Parallel.IntWorkerThreadLocal(NoPeriod)
 
   final def atPhaseStack: List[Phase] = phStack.toList
   final def phase: Phase = ph.get
@@ -242,7 +242,7 @@ abstract class SymbolTable extends macros.Universe
       per.set(nextPeriod)
     } else {
       ph = Parallel.WorkerOrMainThreadLocal(p)
-      per = Parallel.WorkerOrMainThreadLocal(nextPeriod)
+      per = Parallel.IntWorkerThreadLocal(nextPeriod)
     }
   }
 

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -223,60 +223,31 @@ abstract class SymbolTable extends macros.Universe
   final val NoRunId = 0
   // TODO add local for this as well
   private val phStack: collection.mutable.ArrayStack[Phase] = new collection.mutable.ArrayStack()
-  private[this] var ph: Phase = NoPhase
-  private[this] var per = NoPeriod
-
-  private[this] val localPh = new Parallel.WorkerOrMainThreadLocal[Phase](null, null)
-  private[this] val localPer = new Parallel.WorkerOrMainThreadLocal(NoPeriod, NoPeriod)
+  private[this] var ph: Parallel.WorkerOrMainThreadLocal[Phase] = Parallel.WorkerThreadLocal(NoPhase, NoPhase)
+  private[this] var per: Parallel.WorkerOrMainThreadLocal[Int] = Parallel.WorkerThreadLocal(NoPeriod, NoPeriod)
 
   final def atPhaseStack: List[Phase] = phStack.toList
-  final def phase: Phase = localPh.get match {
-    case null => ph
-    case local => local
-  }
+  final def phase: Phase = ph.get
 
   def atPhaseStackMessage = atPhaseStack match {
     case Nil    => ""
     case ps     => ps.reverseMap("->" + _).mkString("(", " ", ")")
   }
 
-  final def localPhase = phase
-
-  final def localPhase_=(p: Phase) {
-    localPh.set(p)
-    if (p == null) localPer.set(NoPeriod)
-    else localPer.set(period(currentRunId, p.id))
-  }
-
   final def phase_=(p: Phase) {
-    assert(localPh.get eq null)
-    //System.out.println("setting phase to " + p)
     assert((p ne null) && p != NoPhase, p)
-    ph = p
-    per = period(currentRunId, p.id)
-  }
-
-
-  @inline final def withLocalPhase[T](op: => T): T = {
-    val previous = localPh.get
-    try op finally localPhase = previous
-  }
-
-  final def pushPhase(ph: Phase): Phase = {
-    val current = phase
-    phase = ph
-    if (keepPhaseStack) {
-      phStack.push(ph)
+    val nextPeriod = period(currentRunId, p.id)
+    if (Parallel.isWorker.get()) {
+      ph.set(p)
+      per.set(nextPeriod)
+    } else {
+      ph = Parallel.WorkerThreadLocal(p, p)
+      per = Parallel.WorkerThreadLocal(nextPeriod, nextPeriod)
     }
-    current
   }
-  final def popPhase(ph: Phase) = {
-    if (keepPhaseStack) {
-      phStack.pop()
-    }
-    phase = ph
-  }
+
   var keepPhaseStack: Boolean = false
+
 
   /** The current compiler run identifier. */
   def currentRunId: RunId
@@ -290,10 +261,7 @@ abstract class SymbolTable extends macros.Universe
   /** The current period. */
   final def currentPeriod: Period = {
     //assert(per == (currentRunId << 8) + phase.id)
-    localPer.get match {
-      case NoPeriod => per
-      case local => local
-    }
+    per.get
   }
 
   /** The phase associated with given period. */
@@ -306,12 +274,20 @@ abstract class SymbolTable extends macros.Universe
   final def isAtPhaseAfter(p: Phase) =
     p != NoPhase && phase.id > p.id
 
+  @inline final def withSavedPhase[T](op: => T): T = {
+    val previous = phase
+    try op finally phase = previous
+  }
+
   /** Perform given operation at given phase. */
   @inline final def enteringPhase[T](ph: Phase)(op: => T): T = {
     if (ph eq phase) op // opt
-    else withLocalPhase {
-      localPhase = ph
-      op
+    else {
+      if (keepPhaseStack) phStack.push(ph)
+      try withSavedPhase {
+        phase = ph
+        op
+      } finally if (keepPhaseStack) phStack.pop()
     }
   }
 

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -3343,7 +3343,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     }
 
     /** the type this.type in this class */
-    override def thisType: Type = {
+    override def thisType: Type = SymbolLock{
       val period = thisTypePeriod
       if (period != currentPeriod) {
         if (!isValid(period)) thisTypeCache = ThisType(this)
@@ -3435,7 +3435,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
 
     /** the self type of an object foo is foo.type, not class<foo>.this.type
      */
-    override def typeOfThis = {
+    override def typeOfThis = SymbolLock {
       val period = typeOfThisPeriod
       if (period != currentPeriod) {
         if (!isValid(period))

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -223,7 +223,8 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     private def isSynchronized = this.isInstanceOf[scala.reflect.runtime.SynchronizedSymbols#SynchronizedSymbol]
     private def isAprioriThreadsafe = isThreadsafe(AllOps)
 
-    protected object SymbolLock extends Parallel.Lock
+    @inline final def SymbolLock[T](op: => T): T =
+      Parallel.synchronizeAccess(this)(op)
 
     if (!(isCompilerUniverse || isSynchronized || isAprioriThreadsafe))
       throw new AssertionError(s"unsafe symbol $initName (child of $initOwner) in runtime reflection universe") // Not an assert to avoid retention of `initOwner` as a field!

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -1533,9 +1533,9 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
             //          activeLocks += 1
             //         lockedSyms += this
           }
-          withLocalPhase ( try {
+          withSavedPhase ( try {
             assertCorrectThread()
-            localPhase = phaseOf(infos.validFrom)
+            phase = phaseOf(infos.validFrom)
             tp.complete(this)
           } finally unlock())
           cnt += 1
@@ -1615,7 +1615,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
         if (validTo < curPeriod) {
           assertCorrectThread()
           // adapt any infos that come from previous runs
-          withLocalPhase {
+          withSavedPhase {
             val current = phase
             infos = adaptInfos(infos)
 
@@ -1626,7 +1626,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
               var itr = infoTransformers.nextFrom(phaseId(validTo))
               infoTransformers = itr; // caching optimization
               while (itr.pid != NoPhase.id && itr.pid < current.id) {
-                localPhase = phaseWithId(itr.pid)
+                phase = phaseWithId(itr.pid)
                 val info1 = itr.transform(this, infos.info)
                 if (info1 ne infos.info) {
                   infos = TypeHistory(currentPeriod + 1, info1, infos)
@@ -1661,7 +1661,7 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
           val pid = phaseId(infos.validFrom)
 
           _validTo = period(currentRunId, pid)
-          localPhase   = phaseWithId(pid)
+          phase   = phaseWithId(pid)
 
           val info1 = adaptToNewRunMap(infos.info)
           if (info1 eq infos.info) {

--- a/src/reflect/scala/reflect/internal/Trees.scala
+++ b/src/reflect/scala/reflect/internal/Trees.scala
@@ -11,7 +11,7 @@ import Flags._
 import scala.collection.mutable
 import scala.reflect.internal.util.Parallel.Counter
 import scala.reflect.macros.Attachments
-import util.{Statistics, StatisticsStatics}
+import util.{Parallel, Statistics, StatisticsStatics}
 
 trait Trees extends api.Trees {
   self: SymbolTable =>
@@ -97,7 +97,7 @@ trait Trees extends api.Trees {
     override def equals(that: Any) = this eq that.asInstanceOf[AnyRef]
 
     override def duplicate: this.type =
-      (duplicator transform this).asInstanceOf[this.type]
+      (duplicator safeTransform this).asInstanceOf[this.type]
   }
 
   abstract class TreeContextApiImpl extends TreeApi { this: Tree =>
@@ -1780,6 +1780,8 @@ trait Trees extends api.Trees {
       if ((t1 ne t) && t1.pos.isRange && focusPositions) t1 setPos t.pos.focus
       t1
     }
+
+    def safeTransform(tree: Tree) = Parallel.synchronizeAccess(this)(transform(tree))
   }
 
   final def focusInPlace(t: Tree): t.type =

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -99,13 +99,15 @@ trait Types
 
   /** Caching the most recent map has a 75-90% hit rate. */
   private object substTypeMapCache {
-    private[this] var cached: SubstTypeMap = new SubstTypeMap(Nil, Nil)
+    private[this] val cached = Parallel.WorkerThreadLocal(new SubstTypeMap(Nil, Nil))
 
     def apply(from: List[Symbol], to: List[Type]): SubstTypeMap = {
-      if ((cached.from ne from) || (cached.to ne to))
-        cached = new SubstTypeMap(from, to)
-
-      cached
+      val cachedValue = cached.get
+      if ((cachedValue.from ne from) || (cachedValue.to ne to)){
+        val newValue = new SubstTypeMap(from, to)
+        cached.set(newValue)
+        newValue
+      } else cachedValue
     }
   }
 

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -114,7 +114,7 @@ trait Types
   /** The current skolemization level, needed for the algorithms
    *  in isSameType, isSubType that do constraint solving under a prefix.
    */
-  private val _skolemizationLevel = Parallel.WorkerThreadLocal(0)
+  private val _skolemizationLevel = Parallel.IntWorkerThreadLocal(0)
   def skolemizationLevel = _skolemizationLevel.get
   def skolemizationLevel_=(value: Int): Unit = _skolemizationLevel.set(value)
 

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -3965,10 +3965,12 @@ trait Types
   private val initialUniquesCapacity = 4096
   private var uniques: util.WeakHashSet[Type] = _
   private var uniqueRunId = NoRunId
+  object synchronizeUniquesCacheAccess extends Parallel.Lock
 
-  final def howManyUniqueTypes: Int = if (uniques == null) 0 else uniques.size
+  final def howManyUniqueTypes: Int =
+    synchronizeUniquesCacheAccess { if (uniques == null) 0 else uniques.size }
 
-  protected def unique[T <: Type](tp: T): T =  {
+  protected def unique[T <: Type](tp: T): T =  synchronizeUniquesCacheAccess {
     if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(rawTypeCount)
     if (uniqueRunId != currentRunId) {
       uniques = util.WeakHashSet[Type](initialUniquesCapacity)

--- a/src/reflect/scala/reflect/internal/util/Parallel.scala
+++ b/src/reflect/scala/reflect/internal/util/Parallel.scala
@@ -48,6 +48,10 @@ object Parallel {
 
   def WorkerThreadLocal[T](valueOnWorker: => T) = new WorkerThreadLocal[T](valueOnWorker)
 
+  class Lock {
+    @inline final def apply[T](op: => T) = synchronizeAccess(this)(op)
+  }
+
   abstract class AbstractThreadLocal[T](valueOnWorker: => T, valueOnMain: => T) {
     private var main: T = null.asInstanceOf[T]
 


### PR DESCRIPTION
By:
- Turn off most of synchronization logic for non-parallel phases
- Make out Threadlocals eager and improve their perfromance (and create Lazy version as well)
- Change the way how most common threadLocals are applied (so basically remove creating of 400k them)
- Create specielized ThreadLocal for ints

It boosts perfomance from 28,374 (build 329) to 23,702 (build 328). Overhead is still quite bing (non-parallel run is 20,121) **~17,79%**.

Performance of refcheck is slightly better in this PR (0,929 vs. 0,906) where on non parallel we've get 1,248, so it means **~27,4%** speedup. When running refchecks on  this PR but in non parallel we get 1,367 so relative speedup of parallelization is **33,7%**.