### PR TITLE
Diagnostic for HashSet (do not merge)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -202,6 +202,18 @@ val mimaFilterSettings = Seq {
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashSet#LeafHashSet.this"),
 
     // Some static forwarder changes detected after a MiMa upgrade.
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashSet.elemHashCode"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashSet.computeHash"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashSet.improve"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashSet#HashTrieSet.bitmap"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashSet#HashTrieSet.bitmap_="),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashSet#HashTrieSet.elems_="),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashSet#HashTrieSet.size0"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.HashSet#HashTrieSet.size0_="),
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.HashSet$HashSetBuilder"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.collection.immutable.Set$SetBuilderImpl"),
+
+  // Some static forwarder changes detected after a MiMa upgrade.
     // e.g. static method apply(java.lang.Object)java.lang.Object in class scala.Symbol does not have a correspondent in current version
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Symbol.apply"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("scala.sys.process.Process.Future"),

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -19,7 +19,6 @@ import java.util
 import generic._
 import scala.collection.parallel.immutable.ParHashSet
 import scala.annotation.tailrec
-import scala.collection.mutable.SetBuilder
 
 /** This class implements immutable sets using a hash trie.
  *
@@ -41,7 +40,7 @@ sealed class HashSet[A] extends AbstractSet[A]
                     with CustomParallelizable[A, ParHashSet[A]]
                     with Serializable
 {
-  import HashSet.{nullToEmpty, bufferSize}
+  import HashSet.{nullToEmpty, bufferSize, computeHash}
 
   override def companion: GenericCompanion[HashSet] = HashSet
 
@@ -183,17 +182,6 @@ sealed class HashSet[A] extends AbstractSet[A]
 
   protected def filter0(p: A => Boolean, negate: Boolean, level: Int, buffer: Array[HashSet[A]], offset0: Int): HashSet[A] = null
 
-  protected def elemHashCode(key: A) = key.##
-
-  protected final def improve(hcode: Int) = {
-    var h: Int = hcode + ~(hcode << 9)
-    h = h ^ (h >>> 14)
-    h = h + (h << 4)
-    h ^ (h >>> 10)
-  }
-
-  private[collection] def computeHash(key: A) = improve(elemHashCode(key))
-
   protected def get0(key: A, hash: Int, level: Int): Boolean = false
 
   private[collection] def updated0(key: A, hash: Int, level: Int): HashSet[A] =
@@ -218,12 +206,7 @@ sealed class HashSet[A] extends AbstractSet[A]
  *  @define willNotTerminateInf
  */
 object HashSet extends ImmutableSetFactory[HashSet] {
-  override def newBuilder[A]: mutable.Builder[A, HashSet[A]] = new SetBuilder[A, HashSet[A]](empty[A]) {
-    override def ++=(xs: TraversableOnce[A]): this.type = {
-      elems = elems ++ xs
-      this
-    }
-  }
+  override def newBuilder[A]: mutable.Builder[A, HashSet[A]] = new HashSetBuilder[A]
 
   /** $setCanBuildFromInfo */
   implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, HashSet[A]] =
@@ -541,8 +524,9 @@ object HashSet extends ImmutableSetFactory[HashSet] {
    * elems: [a,b]
    * children:        ---b----------------a-----------
    */
-  class HashTrieSet[A](private val bitmap: Int, private[collection] val elems: Array[HashSet[A]], override val size: Int)
+  class HashTrieSet[A](private[HashSet] var bitmap: Int, private[collection] var elems: Array[HashSet[A]], private[HashSet] var size0: Int)
         extends HashSet[A] {
+    @inline override def size = size0
     // assert(Integer.bitCount(bitmap) == elems.length)
     // assertion has to remain disabled until scala/bug#6197 is solved
     // assert(elems.length > 1 || (elems.length == 1 && elems(0).isInstanceOf[HashTrieSet[_]]))
@@ -1113,6 +1097,16 @@ object HashSet extends ImmutableSetFactory[HashSet] {
       }
     }
   }
+  protected def elemHashCode(key: Any) = key.##
+
+  protected final def improve(hcode: Int) = {
+    var h: Int = hcode + ~(hcode << 9)
+    h = h ^ (h >>> 14)
+    h = h + (h << 4)
+    h ^ (h >>> 10)
+  }
+
+  private[collection] def computeHash(key: Any) = improve(elemHashCode(key))
 
   /**
    * Calculates the maximum buffer size given the maximum possible total size of the trie-based collection
@@ -1183,4 +1177,279 @@ object HashSet extends ImmutableSetFactory[HashSet] {
     private def readResolve(): AnyRef = orig
   }
 
+
+  /** Builder for HashSet.
+   */
+  private[collection] final class HashSetBuilder[A] extends mutable.ReusableBuilder[A, HashSet[A]] {
+
+
+    /* Nodes in the tree are either regular HashSet1, HashTrieSet, HashSetCollision1, or a mutable HashTrieSet
+      mutable HashTrieSet nodes are designated by having size == -1
+
+      mutable HashTrieSet nodes can have child nodes that are mutable, or immutable
+      immutable HashTrieSet child nodes can only be immutable
+
+      mutable HashTrieSet elems are always a Array of size 32,size -1, bitmap -1
+     */
+
+    /** The root node of the partially build hashmap */
+    private var rootNode: HashSet[A] = HashSet.empty
+
+    private def isMutable(hs: HashSet[A]) = {
+      hs.isInstanceOf[HashTrieSet[A]] && hs.size == -1
+    }
+
+    private def makeMutable(hs: HashTrieSet[A]): HashTrieSet[A] = {
+      if (isMutable(hs)) hs
+      else {
+        val elems = new Array[HashSet[A]](32)
+        var bit = 0
+        var iBit = 0
+        while (bit < 32) {
+          if ((hs.bitmap & (1 << bit)) != 0) {
+            elems(bit) = hs.elems(iBit)
+            iBit += 1
+          }
+          bit += 1
+        }
+        new HashTrieSet[A](-1, elems, -1)
+      }
+    }
+
+    private def makeImmutable(hs: HashSet[A]): HashSet[A] = {
+      hs match {
+        case trie: HashTrieSet[A] if isMutable(trie) =>
+          var bit = 0
+          var bitmap = 0
+          var size = 0
+          while (bit < 32) {
+            if (trie.elems(bit) ne null)
+              trie.elems(bit) = makeImmutable(trie.elems(bit))
+            if (trie.elems(bit) ne null) {
+              bitmap |= 1 << bit
+              size += trie.elems(bit).size
+            }
+            bit += 1
+          }
+          Integer.bitCount(bitmap) match {
+            case 0 => null
+            case 1
+              if trie.elems(Integer.numberOfTrailingZeros(bitmap)).isInstanceOf[LeafHashSet[A]] =>
+              trie.elems(Integer.numberOfTrailingZeros(bitmap))
+
+            case bc =>
+              val elems = if (bc == 32) trie.elems else {
+                val elems = new Array[HashSet[A]](bc)
+                var oBit = 0
+                bit = 0
+                while (bit < 32) {
+                  if (trie.elems(bit) ne null) {
+                    elems(oBit) = trie.elems(bit)
+                    oBit += 1
+                  }
+                  bit += 1
+                }
+                assert(oBit == bc)
+                elems
+              }
+              trie.size0 = size
+              trie.elems = elems
+              trie.bitmap = bitmap
+              trie
+          }
+        case _ => hs
+      }
+    }
+
+    override def clear(): Unit = {
+      rootNode match {
+        case trie: HashTrieSet[A] if isMutable(trie) =>
+          util.Arrays.fill(trie.elems.asInstanceOf[Array[AnyRef]], null)
+        case _ => rootNode = HashSet.empty
+      }
+    }
+
+    override def result(): HashSet[A] = {
+        rootNode = nullToEmpty(makeImmutable(rootNode))
+        rootNode
+    }
+
+
+    override def +=(elem1: A, elem2: A, elems: A*): HashSetBuilder.this.type = {
+      this += elem1
+      this += elem2
+      this ++= elems
+    }
+
+    override def +=(elem: A): HashSetBuilder.this.type = {
+      val hash = computeHash(elem)
+      rootNode = addOne(rootNode, elem, hash, 0)
+      this
+    }
+
+    override def ++=(xs: TraversableOnce[A]): HashSetBuilder.this.type = xs match {
+      case hs: HashSet[A] =>
+        if (rootNode eq EmptyHashSet)
+          rootNode = hs
+        else
+          rootNode = addHashSet(rootNode, hs, 0)
+        this
+      //      case hs: HashMap.HashMapKeys =>
+      //      //TODO
+      case hs: mutable.HashSet[A] =>
+        //TODO
+        super.++=(xs)
+      case _ =>
+        super.++=(xs)
+    }
+
+    def makeMutableTrie(aLeaf: LeafHashSet[A], bLeaf: LeafHashSet[A], level: Int): HashTrieSet[A] = {
+      val elems = new Array[HashSet[A]](32)
+      val aRawIndex = (aLeaf.hash >>> level) & 0x1f
+      val bRawIndex = (bLeaf.hash >>> level) & 0x1f
+      if (aRawIndex == bRawIndex) {
+        elems(aRawIndex) = makeMutableTrie(aLeaf, bLeaf, level + 5)
+      } else {
+        elems(aRawIndex) = aLeaf
+        elems(bRawIndex) = bLeaf
+      }
+      new HashTrieSet[A](-1, elems, -1)
+    }
+
+    def makeMutableTrie(leaf: LeafHashSet[A], elem: A, elemImprovedHash: Int, level: Int): HashTrieSet[A] = {
+      makeMutableTrie(leaf, new HashSet1(elem, elemImprovedHash), level)
+    }
+
+    private def addOne(toNode: HashSet[A], elem: A, improvedHash: Int, level: Int): HashSet[A] = {
+      toNode match {
+        case leaf: LeafHashSet[A] =>
+          if (leaf.hash == improvedHash)
+            leaf.updated0(elem, improvedHash, level)
+          else makeMutableTrie(leaf, elem, improvedHash, level)
+
+        case trie: HashTrieSet[A] if isMutable((trie)) =>
+          val arrayIndex = (improvedHash >>> level) & 0x1f
+          val old = trie.elems(arrayIndex)
+          trie.elems(arrayIndex) = if (old eq null) new HashSet1(elem, improvedHash)
+          else addOne(old, elem, improvedHash, level + 5)
+          trie
+
+        case trie: HashTrieSet[A] =>
+          val rawIndex = (improvedHash >>> level) & 0x1f
+          if ((trie.bitmap & (1 << rawIndex)) == 0)
+            addOne(makeMutable(trie), elem, improvedHash, level)
+          else {
+            val arrayIndex = compressedIndex(trie, rawIndex)
+
+            val old = trie.elems(arrayIndex)
+            val merged = if (old eq null) new HashSet1(elem, improvedHash)
+            else addOne(old, elem, improvedHash, level + 5)
+
+            if (merged eq old) trie
+            else {
+              val newMutableTrie = makeMutable(trie)
+              newMutableTrie.elems(rawIndex) = merged
+              newMutableTrie
+            }
+          }
+        case empty if empty eq EmptyHashSet => toNode.updated0(elem, improvedHash, level)
+      }
+    }
+
+    private def compressedIndex(trie: HashTrieSet[A], rawIndex: Int): Int = {
+      if (trie.bitmap == -1) rawIndex
+      else {
+        Integer.bitCount(((1 << rawIndex) - 1) & trie.bitmap)
+      }
+    }
+    private def trieIndex(trie: HashTrieSet[A], rawIndex: Int): Int = {
+      if (isMutable(trie) || trie.bitmap == -1) rawIndex
+      else compressedIndex(trie, rawIndex)
+    }
+
+    private def addHashSet(toNode: HashSet[A], toBeAdded: HashSet[A], level: Int): HashSet[A] = {
+      toNode match {
+        case aLeaf: LeafHashSet[A] => addToLeafHashSet(aLeaf, toBeAdded, level)
+        case trie: HashTrieSet[A] => addToTrieHashSet(trie, toBeAdded, level)
+        case empty if empty eq EmptyHashSet => toNode
+      }
+    }
+
+    private def addToTrieHashSet(toNode: HashTrieSet[A], toBeAdded: HashSet[A], level: Int): HashSet[A] = {
+      if (toNode eq toBeAdded) toNode
+      else toBeAdded match {
+        case bLeaf: LeafHashSet[A] =>
+          val rawIndex = (bLeaf.hash >>> level) & 0x1f
+          val arrayIndex = trieIndex(toNode, rawIndex)
+          val old = toNode.elems(arrayIndex)
+          if (old eq toBeAdded) toNode
+          else if (old eq null) {
+            assert (isMutable(toNode))
+            toNode.elems(arrayIndex) = toBeAdded
+            toNode
+          } else {
+            val result = addHashSet(old, toBeAdded, level + 5)
+            if (result eq old) toNode
+            else {
+              val newToNode = makeMutable(toNode)
+              newToNode.elems(rawIndex) = result
+              newToNode
+            }
+          }
+        case bTrie: HashTrieSet[A] =>
+          var result = toNode
+          var bBitSet = bTrie.bitmap
+          var bArrayIndex = 0
+          while (bBitSet != 0) {
+            val rawIndex = Integer.numberOfTrailingZeros(bBitSet)
+            val aValue = result.elems(trieIndex(result, rawIndex))
+            val bValue = bTrie.elems(bArrayIndex)
+            if (aValue ne bValue) {
+              if (aValue eq null) {
+                assert (isMutable(result))
+                result.elems(rawIndex) = bValue
+              } else {
+                val resultAtIndex = addHashSet(aValue, bValue, level + 5)
+                if (resultAtIndex ne aValue) {
+                  result = makeMutable(result)
+                  result.elems(rawIndex) = resultAtIndex
+                }
+              }
+            }
+            bBitSet ^= 1 << rawIndex
+            bArrayIndex += 1
+          }
+          result
+
+        case empty if empty eq EmptyHashSet => toNode
+      }
+    }
+    private def addToLeafHashSet(toNode: LeafHashSet[A], toBeAdded: HashSet[A], level: Int): HashSet[A] = {
+      if (toNode eq toBeAdded) toNode
+      else toBeAdded match {
+        case bLeaf: LeafHashSet[A] =>
+          if (toNode.hash == bLeaf.hash) toNode.union0(bLeaf, level)
+          else makeMutableTrie(toNode, bLeaf, level)
+        case bTrie: HashTrieSet[A] =>
+          val rawIndex = (toNode.hash >>> level) & 0x1f
+          val arrayIndex = compressedIndex(bTrie, rawIndex)
+          if ((bTrie.bitmap & arrayIndex) == 0) {
+            val result = makeMutable(bTrie)
+            result.elems(rawIndex) = toNode
+            result
+          } else {
+            val newEle = addToLeafHashSet(toNode, bTrie.elems(rawIndex), level + 5)
+            if (newEle eq toBeAdded)
+              toBeAdded
+            else {
+              val result = makeMutable(bTrie)
+              result.elems(rawIndex) = newEle
+              result
+            }
+          }
+        case empty if empty eq EmptyHashSet =>
+          toNode
+      }
+    }
+  }
 }

--- a/src/library/scala/collection/parallel/immutable/ParHashSet.scala
+++ b/src/library/scala/collection/parallel/immutable/ParHashSet.scala
@@ -140,11 +140,12 @@ private[immutable] abstract class HashSetCombiner[T]
 extends scala.collection.parallel.BucketCombiner[T, ParHashSet[T], Any, HashSetCombiner[T]](HashSetCombiner.rootsize) {
 //self: EnvironmentPassingCombiner[T, ParHashSet[T]] =>
   import HashSetCombiner._
+  import HashSet.computeHash
   val emptyTrie = HashSet.empty[T]
 
   def +=(elem: T) = {
     sz += 1
-    val hc = emptyTrie.computeHash(elem)
+    val hc = computeHash(elem)
     val pos = hc & 0x1f
     if (buckets(pos) eq null) {
       // initialize bucket
@@ -200,7 +201,7 @@ extends scala.collection.parallel.BucketCombiner[T, ParHashSet[T], Any, HashSetC
         val chunksz = unrolled.size
         while (i < chunksz) {
           val v = chunkarr(i).asInstanceOf[T]
-          val hc = trie.computeHash(v)
+          val hc = computeHash(v)
           trie = trie.updated0(v, hc, rootbits)  // internal API, private[collection]
           i += 1
         }

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/HashSetBenchmarkData.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/HashSetBenchmarkData.scala
@@ -1,0 +1,14 @@
+package scala.collection.immutable
+
+object HashSetBenchmarkData {
+  def apply(hashCode: Int, data: String) = new HashSetBenchmarkData(hashCode, data.intern())
+}
+
+class HashSetBenchmarkData private(override val hashCode: Int, val data: String) {
+  override def equals(obj: Any): Boolean = obj match {
+    case that: HashSetBenchmarkData => this.hashCode == that.hashCode && (this.data eq that.data)
+    case _ => false
+  }
+
+  override def toString: String = s"$hashCode-$data"
+}

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/HashSetBuilderBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/HashSetBuilderBenchmark.scala
@@ -1,0 +1,249 @@
+package scala.collection.immutable
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra._
+
+//typically run with
+// bench/jmh:run scala.collection.immutable.HashSetBuilder -prof gc -rf csv
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+abstract class HashSetBuilderBaseBenchmark {
+  @Param(Array(
+    "10",
+    "100",
+    "1000",
+    "10000"))
+  var size: Int = _
+  @Param(Array("true", "false"))
+  var colliding: Boolean = _
+
+  @Param(Array("Set+=", "Set++=", "HashSet+=", "HashSet++="))
+  var op: String = _
+  var operation: (Blackhole, Set[HashSetBenchmarkData], Set[HashSetBenchmarkData]) => Any = _
+
+  // base data of specified size. All values are distinct
+  var baseData: Array[HashSet[HashSetBenchmarkData]] = _
+  // overlap(i) contains baseData(i) .. baseData(i+9) but with no structural sharing
+  var overlap: Array[HashSet[HashSetBenchmarkData]] = _
+  // overlap2(i) contains the same data as overlap(i) but with no structural sharing
+  var overlap2: Array[HashSet[HashSetBenchmarkData]] = _
+  // shared(i) contains baseData(i) .. baseData(i+9) but with structural sharing, both to the base data and preceding/subsequent entries
+  var shared: Array[HashSet[HashSetBenchmarkData]] = _
+
+
+  @Setup(Level.Trial) def initKeys(): Unit = {
+    operation = op match {
+      case "Set+=" => operationSetPlusEquals
+      case "Set++=" => operationSetPlusPlusEquals
+      case "HashSet+=" => operationHashSetPlusEquals
+      case "HashSet++=" => operationHashSetPlusPlusEquals
+    }
+
+    def generate(prefix: String, size: Int) = {
+      Array.tabulate(30)(i => (0 until size).map { k =>
+        val data = s"key $i $k"
+        val hash = if (colliding) (k >> 2) * i else data.hashCode
+        HashSetBenchmarkData(hash, data)
+      }(scala.collection.breakOut): HashSet[HashSetBenchmarkData])
+    }
+
+    baseData = generate("", size)
+
+    overlap = new Array[HashSet[HashSetBenchmarkData]](baseData.length - 10)
+    overlap2 = new Array[HashSet[HashSetBenchmarkData]](baseData.length - 10)
+    shared = new Array[HashSet[HashSetBenchmarkData]](baseData.length - 10)
+    for (i <- 0 until baseData.length - 10) {
+      var s1: HashSet[HashSetBenchmarkData] = HashSet.empty[HashSetBenchmarkData]
+      var s2: HashSet[HashSetBenchmarkData] = HashSet.empty[HashSetBenchmarkData]
+      for (j <- i until i + 10) {
+        baseData(j) foreach {
+          x =>
+            s1 += x
+            s2 += x
+        }
+      }
+      overlap(i) = s1
+      overlap2(i) = s2
+    }
+
+    def base(i: Int) = {
+      baseData(if (i < 0) baseData.length + i else i)
+    }
+
+    shared(0) = (-10 to(0, 1)).foldLeft(base(-10)) { case (a, b) => a ++ base(b) }
+    for (i <- 1 until shared.length) {
+      shared(i) = shared(i - 1) -- base(i - 10) ++ base(i)
+    }
+
+  }
+
+  def operationSetPlusEquals(bh: Blackhole, set1: Set[HashSetBenchmarkData], set2: Set[HashSetBenchmarkData]) = {
+    val builder = Set.newBuilder[HashSetBenchmarkData]
+    builder ++= set1
+    set2 foreach {
+      builder += _
+    }
+    bh.consume(builder.result)
+  }
+
+  def operationSetPlusPlusEquals(bh: Blackhole, set1: Set[HashSetBenchmarkData], set2: Set[HashSetBenchmarkData]) = {
+    val builder = Set.newBuilder[HashSetBenchmarkData]
+    builder ++= set1
+    builder ++= set2
+    bh.consume(builder.result)
+  }
+
+  def operationHashSetPlusEquals(bh: Blackhole, set1: Set[HashSetBenchmarkData], set2: Set[HashSetBenchmarkData]) = {
+    val builder = Set.newBuilder[HashSetBenchmarkData]
+    builder ++= set1
+    set2 foreach {
+      builder += _
+    }
+    bh.consume(builder.result)
+  }
+
+  def operationHashSetPlusPlusEquals(bh: Blackhole, set1: Set[HashSetBenchmarkData], set2: Set[HashSetBenchmarkData]) = {
+    val builder = Set.newBuilder[HashSetBenchmarkData]
+    builder ++= set1
+    builder ++= set2
+    bh.consume(builder.result)
+  }
+}
+
+class HashSetBuilderUnsharedBenchmark extends HashSetBuilderBaseBenchmark {
+
+  @OperationsPerInvocation(30)
+  @Benchmark def opDataWithEmpty(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < 30) {
+      operation(bh, baseData(i), HashSet.empty)
+      i += 1
+    }
+  }
+
+  @OperationsPerInvocation(30)
+  @Benchmark def opEmptyWithData(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < 30) {
+      operation(bh, HashSet.empty, baseData(i))
+      i += 1
+    }
+  }
+
+  @OperationsPerInvocation(30)
+  @Benchmark def opDataWithSetEmpty(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < 30) {
+      operation(bh, baseData(i), Set.empty)
+      i += 1
+    }
+  }
+
+  @OperationsPerInvocation(30)
+  @Benchmark def opSetEmptyWithData(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < 30) {
+      operation(bh, Set.empty, baseData(i))
+      i += 1
+    }
+  }
+
+  @OperationsPerInvocation(29)
+  @Benchmark def opWithDistinct(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < 29) {
+      operation(bh, baseData(i), baseData(i + 1))
+      i += 1
+    }
+  }
+
+  @OperationsPerInvocation(20)
+  @Benchmark def opDataWithContainedUnshared(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < 20) {
+      operation(bh, overlap(i), baseData(i))
+      i += 1
+    }
+  }
+
+  @OperationsPerInvocation(20)
+  @Benchmark def opDataWithContainedShared(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < 20) {
+      operation(bh, shared(i), baseData(i))
+      i += 1
+    }
+  }
+
+  @OperationsPerInvocation(20)
+  @Benchmark def opContainedUnsharedWithData(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < 20) {
+      operation(bh, baseData(i), overlap(i))
+      i += 1
+    }
+  }
+
+  @OperationsPerInvocation(20)
+  @Benchmark def opContainedSharedWithData(bh: Blackhole): Unit = {
+    var i = 0;
+    while (i < 20) {
+      operation(bh, baseData(i), shared(i))
+      i += 1
+    }
+  }
+}
+
+class HashSetBuilderSharedBenchmark extends HashSetBuilderBaseBenchmark {
+  @Param(Array("0", "20", "40", "60", "80", "90", "100"))
+  var sharing: Int = _
+
+  @OperationsPerInvocation(10)
+  @Benchmark def opWithOverlapUnshared(bh: Blackhole): Unit = {
+    var i = 10;
+    while (i < 20) {
+      operation(bh, overlap(i - (10 - sharing / 10)), overlap2(i))
+      i += 1
+    }
+  }
+
+  @OperationsPerInvocation(10)
+  @Benchmark def opWithOverlapShared(bh: Blackhole): Unit = {
+    var i = 10;
+    while (i < 20) {
+      operation(bh, shared(i - (10 - sharing / 10)), shared(i))
+      i += 1
+    }
+  }
+}
+
+
+//for testing, debugging, optimising etc
+object TestHashSetBenchmark extends App {
+
+  val bh = new Blackhole("Today's password is swordfish. I understand instantiating Blackholes directly is dangerous.")
+  val test = new HashSetBuilderUnsharedBenchmark
+
+  test.size = 10000
+  test.op = "++"
+  test.colliding = true
+  test.initKeys()
+  while (true) {
+    var j = 0
+    val start = System.nanoTime()
+    while (j < 100) {
+      test.opDataWithContainedUnshared(bh)
+      j += 1
+    }
+    val end = System.nanoTime()
+    println((end - start) / 1000000)
+  }
+}

--- a/test/benchmarks/src/main/scala/scala/collection/immutable/HashSetBulkBenchmark.scala
+++ b/test/benchmarks/src/main/scala/scala/collection/immutable/HashSetBulkBenchmark.scala
@@ -226,19 +226,8 @@ abstract class HashSetBaseBulkBenchmark {
     bh.consume(set1.sameElements(set2))
   }
 }
-object HashSetBenchmarkData {
-  def apply(hashCode: Int, data: String) = new HashSetBenchmarkData(hashCode, data.intern())
-}
-class HashSetBenchmarkData private (override val hashCode: Int, val data: String) {
-  override def equals(obj: Any): Boolean = obj match {
-    case that: HashSetBenchmarkData => this.hashCode == that.hashCode && (this.data eq that.data)
-    case _ => false
-  }
-
-  override def toString: String = s"$hashCode-$data"
-}
 //for testing, debugging, optimising etc
-object Test extends App {
+object HashSetBulkBenchmarkTestApp extends App {
 
   val bh = new Blackhole("Today's password is swordfish. I understand instantiating Blackholes directly is dangerous.")
   val test = new HashSetBulkUnsharedBenchmark

--- a/test/junit/scala/collection/immutable/HashSetTest.scala
+++ b/test/junit/scala/collection/immutable/HashSetTest.scala
@@ -1,7 +1,7 @@
 package scala.collection.immutable
 
 import org.junit.Assert._
-import org.junit.Test
+import org.junit.{Assert, Test}
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
@@ -218,21 +218,25 @@ class HashSetTest extends AllocationTest {
 
   @Test
   def optimizedAppendAllWorks(): Unit = {
-    case class C(i: Int) {
-      override def hashCode: Int = i % 1024
-    }
+    case class C(i: Int) { override def hashCode: Int = i % 1024 }
     val setReference = collection.mutable.HashSet[C]()
-    val builder0 = collection.immutable.HashSet.newBuilder[C];
-    for (i <- 1 to 16) {
-      val builder1 = collection.immutable.HashSet.newBuilder[C];
-      for (i <- 1 to 8)
-        builder1 += C(scala.util.Random.nextInt());
-      val s1 = builder1.result()
-      builder0 ++= s1
-      setReference ++= s1
+    for (i <- 1 to 10) {
+      println("iteration " + i)
+      val builder0 = collection.immutable.HashSet.newBuilder[C];
+      for (i <- 1 to 16) {
+        val builder1 = collection.immutable.HashSet.newBuilder[C];
+        for (i <- 1 to 8)
+          builder1 += C(scala.util.Random.nextInt());
+        val s1 = builder1.result()
+        builder0 ++= s1
+        setReference ++= s1
+      }
+      val set0 = builder0.result()
+      set0.foreach(_.hashCode)
+      if (set0 != setReference) {
+        set0.printDebug()
+        Assert.fail("not equals")
+      }
     }
-    val set0 = builder0.result()
-    assertEquals(set0, setReference)
   }
-
 }

--- a/test/junit/scala/collection/immutable/HashSetTest.scala
+++ b/test/junit/scala/collection/immutable/HashSetTest.scala
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import scala.tools.testing.AllocationTest
+import scala.util.Random
 
 @RunWith(classOf[JUnit4])
 class HashSetTest extends AllocationTest {
@@ -213,6 +214,25 @@ class HashSetTest extends AllocationTest {
     assertSame(initial, initial + first)
     assertSame(initial, initial + new Colliding(first.hashCode, first.other))
 
+  }
+
+  @Test
+  def optimizedAppendAllWorks(): Unit = {
+    case class C(i: Int) {
+      override def hashCode: Int = i % 1024
+    }
+    val setReference = collection.mutable.HashSet[C]()
+    val builder0 = collection.immutable.HashSet.newBuilder[C];
+    for (i <- 1 to 16) {
+      val builder1 = collection.immutable.HashSet.newBuilder[C];
+      for (i <- 1 to 8)
+        builder1 += C(scala.util.Random.nextInt());
+      val s1 = builder1.result()
+      builder0 ++= s1
+      setReference ++= s1
+    }
+    val set0 = builder0.result()
+    assertEquals(set0, setReference)
   }
 
 }

--- a/test/junit/scala/collection/immutable/HashSetTest.scala
+++ b/test/junit/scala/collection/immutable/HashSetTest.scala
@@ -184,8 +184,6 @@ class HashSetTest extends AllocationTest {
     })
   }
 
-
-
   def generateWithCollisions(start:Int, end:Int): HashSet[Colliding] = {
     (start to end).map { i => new Colliding(i/10, s"key $i") }(scala.collection.breakOut)
   }


### PR DESCRIPTION
```
/Users/jz/.jabba/jdk/adopt@1.8.212-04/Contents/Home/bin/java -agentlib:jdwp=transport=dt_socket,address=127.0.0.1:59491,suspend=y,server=n -ea -Didea.test.cyclic.buffer.size=1048576 -javaagent:/Users/jz/Library/Caches/JetBrains/IntelliJIdea2020.1/captureAgent/debugger-agent.jar -agentpath:/private/var/folders/22/g1sv634d11j1d_lqlnhz9p2r0000gn/T/libmemory_agent701.dylib= -Dfile.encoding=UTF-8 -classpath "/Users/jz/Library/Application Support/JetBrains/Toolbox/apps/IDEA-U/ch-0/201.4865.12/IntelliJ IDEA 2020.1 EAP.app/Contents/lib/idea_rt.jar:/Users/jz/Library/Application Support/JetBrains/Toolbox/apps/IDEA-U/ch-0/201.4865.12/IntelliJ IDEA 2020.1 EAP.app/Contents/plugins/junit/lib/junit5-rt.jar:/Users/jz/Library/Application Support/JetBrains/Toolbox/apps/IDEA-U/ch-0/201.4865.12/IntelliJ IDEA 2020.1 EAP.app/Contents/plugins/junit/lib/junit-rt.jar:/Users/jz/.jabba/jdk/adopt@1.8.212-04/Contents/Home/jre/lib/charsets.jar:/Users/jz/.jabba/jdk/adopt@1.8.212-04/Contents/Home/jre/lib/ext/cldrdata.jar:/Users/jz/.jabba/jdk/adopt@1.8.212-04/Contents/Home/jre/lib/ext/dnsns.jar:/Users/jz/.jabba/jdk/adopt@1.8.212-04/Contents/Home/jre/lib/ext/jaccess.jar:/Users/jz/.jabba/jdk/adopt@1.8.212-04/Contents/Home/jre/lib/ext/localedata.jar:/Users/jz/.jabba/jdk/adopt@1.8.212-04/Contents/Home/jre/lib/ext/nashorn.jar:/Users/jz/.jabba/jdk/adopt@1.8.212-04/Contents/Home/jre/lib/ext/sunec.jar:/Users/jz/.jabba/jdk/adopt@1.8.212-04/Contents/Home/jre/lib/ext/sunjce_provider.jar:/Users/jz/.jabba/jdk/adopt@1.8.212-04/Contents/Home/jre/lib/ext/sunpkcs11.jar:/Users/jz/.jabba/jdk/adopt@1.8.212-04/Contents/Home/jre/lib/ext/zipfs.jar:/Users/jz/.jabba/jdk/adopt@1.8.212-04/Contents/Home/jre/lib/jce.jar:/Users/jz/.jabba/jdk/adopt@1.8.212-04/Contents/Home/jre/lib/jsse.jar:/Users/jz/.jabba/jdk/adopt@1.8.212-04/Contents/Home/jre/lib/management-agent.jar:/Users/jz/.jabba/jdk/adopt@1.8.212-04/Contents/Home/jre/lib/resources.jar:/Users/jz/.jabba/jdk/adopt@1.8.212-04/Contents/Home/jre/lib/rt.jar:/Users/jz/.jabba/jdk/adopt@1.8.212-04/Contents/Home/lib/dt.jar:/Users/jz/.jabba/jdk/adopt@1.8.212-04/Contents/Home/lib/jconsole.jar:/Users/jz/.jabba/jdk/adopt@1.8.212-04/Contents/Home/lib/sa-jdi.jar:/Users/jz/.jabba/jdk/adopt@1.8.212-04/Contents/Home/lib/tools.jar:/Users/jz/code/scala/target/junit/test-classes:/Users/jz/code/scala/build/quick/classes/library:/Users/jz/code/scala/build/quick/classes/reflect:/Users/jz/code/scala/build/quick/classes/compiler:/Users/jz/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/ant/ant/1.9.4/ant-1.9.4.jar:/Users/jz/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/jline/jline/2.14.6/jline-2.14.6.jar:/Users/jz/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.0.6/scala-xml_2.12-1.0.6.jar:/Users/jz/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/fusesource/jansi/jansi/1.12/jansi-1.12.jar:/Users/jz/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/apache/ant/ant-launcher/1.9.4/ant-launcher-1.9.4.jar:/Users/jz/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-asm/7.3.1-scala-1/scala-asm-7.3.1-scala-1.jar:/Users/jz/code/scala/build/quick/classes/repl:/Users/jz/code/scala/build/quick/classes/interactive:/Users/jz/code/scala/build/quick/classes/scaladoc:/Users/jz/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/webjars/jquery/3.4.1/jquery-3.4.1.jar:/Users/jz/code/scala/build/quick/classes/partest-extras:/Users/jz/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-sbt/test-interface/1.0/test-interface-1.0.jar:/Users/jz/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/googlecode/java-diff-utils/diffutils/1.3.0/diffutils-1.3.0.jar:/Users/jz/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-partest_2.12/1.1.9/scala-partest_2.12-1.1.9.jar:/Users/jz/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/openjdk/jol/jol-core/0.9/jol-core-0.9.jar:/Users/jz/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar:/Users/jz/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar" com.intellij.rt.junit.JUnitStarter -ideVersion5 -junit4 scala.collection.immutable.HashSetTest,optimizedAppendAllWorks
Connected to the target VM, address: '127.0.0.1:59491', transport: 'socket'
iteration 1
 HashTrieSet@134310351
   HashSet1@2074185499
   HashTrieSet@17037394
     HashSet1@1151593579
     HashSet1@1988859660
     HashTrieSet@1411892748
       HashSet1@22805895
       HashSet1@1514160588
     HashSet1@1413378318
     HashSet1@1475491159
     HashSet1@1640639994
     HashSet1@1263793464
     HashTrieSet@1024429571
       HashSet1@323326911
       HashSet1@1667689440
     HashTrieSet@1270144618
      !! DUPLICATE NODE DETECTED. HashTrieSet@2074185499
       HashSet1@797925218
     HashTrieSet@275310919
       HashSet1@2109874862
       HashSet1@183284570
     HashSet1@1607305514
     HashSet1@146305349
     HashSet1@1686369710
     HashSet1@194706439
     HashSet1@942518407
     HashSet1@1943325854
  !! DUPLICATE NODE DETECTED. HashTrieSet@797925218

java.lang.AssertionError: 
	at scala.collection.immutable.HashSet.$anonfun$selfCheck$1(HashSet.scala:242)
	at scala.collection.immutable.HashSet.$anonfun$selfCheck$1$adapted(HashSet.scala:239)
	at scala.collection.IndexedSeqOptimized.foreach(IndexedSeqOptimized.scala:36)
	at scala.collection.IndexedSeqOptimized.foreach$(IndexedSeqOptimized.scala:33)
	at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:198)
	at scala.collection.immutable.HashSet.loop$2(HashSet.scala:239)
	at scala.collection.immutable.HashSet.$anonfun$selfCheck$1(HashSet.scala:244)
	at scala.collection.immutable.HashSet.$anonfun$selfCheck$1$adapted(HashSet.scala:239)
	at scala.collection.IndexedSeqOptimized.foreach(IndexedSeqOptimized.scala:36)
	at scala.collection.IndexedSeqOptimized.foreach$(IndexedSeqOptimized.scala:33)
	at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:198)
	at scala.collection.immutable.HashSet.loop$2(HashSet.scala:239)
	at scala.collection.immutable.HashSet.$anonfun$selfCheck$1(HashSet.scala:244)
	at scala.collection.immutable.HashSet.$anonfun$selfCheck$1$adapted(HashSet.scala:239)
	at scala.collection.IndexedSeqOptimized.foreach(IndexedSeqOptimized.scala:36)
	at scala.collection.IndexedSeqOptimized.foreach$(IndexedSeqOptimized.scala:33)
	at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:198)
	at scala.collection.immutable.HashSet.loop$2(HashSet.scala:239)
	at scala.collection.immutable.HashSet.selfCheck(HashSet.scala:250)
	at scala.collection.immutable.HashSet$HashSetBuilder.addToTrieHashSet(HashSet.scala:1450)
	at scala.collection.immutable.HashSet$HashSetBuilder.addHashSet(HashSet.scala:1436)
	at scala.collection.immutable.HashSet$HashSetBuilder.addToTrieHashSet(HashSet.scala:1489)
	at scala.collection.immutable.HashSet$HashSetBuilder.addHashSet(HashSet.scala:1436)
	at scala.collection.immutable.HashSet$HashSetBuilder.$plus$plus$eq(HashSet.scala:1352)
	at scala.collection.immutable.HashSet$HashSetBuilder.$plus$plus$eq(HashSet.scala:1240)
	at scala.collection.immutable.HashSetTest.$anonfun$optimizedAppendAllWorks$2(HashSetTest.scala:231)
	at scala.collection.immutable.HashSetTest.$anonfun$optimizedAppendAllWorks$2$adapted(HashSetTest.scala:226)
	at scala.collection.immutable.Range.foreach(Range.scala:158)
	at scala.collection.immutable.HashSetTest.$anonfun$optimizedAppendAllWorks$1(HashSetTest.scala:226)
	at scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:158)
	at scala.collection.immutable.HashSetTest.optimizedAppendAllWorks(HashSetTest.scala:223)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:33)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:230)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:58)

Disconnected from the target VM, address: '127.0.0.1:59491', transport: 'socket'

Process finished with exit code 255


```